### PR TITLE
feature : 이메일 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,13 @@ dependencies {
 	// mysql
 	runtimeOnly 'mysql:mysql-connector-java'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	// mail 관련
+	//spring-boot-starter-mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	// mail 서포트
+	implementation 'org.springframework:spring-context-support:5.3.24'
+	//javax.mail
+	implementation 'com.sun.mail:javax.mail:1.6.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/daangnmarket/daangntoyproject/config/EmailConfig.java
+++ b/src/main/java/daangnmarket/daangntoyproject/config/EmailConfig.java
@@ -1,0 +1,55 @@
+package daangnmarket.daangntoyproject.config;
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+
+@Configuration
+@PropertySource("classpath:email.properties")
+public class EmailConfig {
+
+    @Value("${mail.smtp.port}")
+    private int port;
+    @Value("${mail.smtp.socketFactory.port}")
+    private int socketPort;
+    @Value("${mail.smtp.auth}")
+    private boolean auth;
+    @Value("${mail.smtp.starttls.enable}")
+    private boolean starttls;
+    @Value("${mail.smtp.starttls.required}")
+    private boolean startlls_required;
+    @Value("${mail.smtp.socketFactory.fallback}")
+    private boolean fallback;
+    @Value("${AdminMail.id}")
+    private String id;
+    @Value("${AdminMail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("smtp.gmail.com");
+        javaMailSender.setUsername(id);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+    private Properties getMailProperties()
+    {
+        Properties pt = new Properties();
+        pt.put("mail.smtp.socketFactory.port", socketPort);
+        pt.put("mail.smtp.auth", auth);
+        pt.put("mail.smtp.starttls.enable", starttls);
+        pt.put("mail.smtp.starttls.required", startlls_required);
+        pt.put("mail.smtp.socketFactory.fallback",fallback);
+        pt.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        return pt;
+    }
+}

--- a/src/main/java/daangnmarket/daangntoyproject/config/WebSecurityConfig.java
+++ b/src/main/java/daangnmarket/daangntoyproject/config/WebSecurityConfig.java
@@ -38,7 +38,7 @@ public class WebSecurityConfig  {
         http
                 .csrf().disable()
                 .authorizeHttpRequests((requests) -> requests
-                        .antMatchers("/", "/account/signup",
+                        .antMatchers("/", "/account/**",
                                 "/css/**", "/images/**",
                                 "/js/**", "/api/**", "/oauth/**").permitAll() // 해당 페이지는 모든 사람들이 접속할 수 있는 권한을 부여한다.
                         .anyRequest().authenticated()   // 만약 그냥 "/"만 해주면 css 적용이 안 됨. 따라서 "/css/**"를 해줌으로써 css폴더 안에 있는 하위 파일들을 다 가져오도록 한다.

--- a/src/main/java/daangnmarket/daangntoyproject/user/controller/AccountController.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/controller/AccountController.java
@@ -2,6 +2,7 @@ package daangnmarket.daangntoyproject.user.controller;
 
 import daangnmarket.daangntoyproject.user.model.UserDto;
 import daangnmarket.daangntoyproject.user.service.AccountService;
+import daangnmarket.daangntoyproject.user.service.EmailAuthService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,17 +11,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
-
 @Controller
 @RequestMapping(value = "/account")
 public class AccountController {
     private static final Logger logger = LoggerFactory.getLogger(AccountController.class);
     @Autowired
     private AccountService accountService;
-    public AccountController(AccountService accountService){
-        this.accountService = accountService;
-    }
+    @Autowired
+    private EmailAuthService emailAuthService;
+
+//    public AccountController(AccountService accountService){
+//        this.accountService = accountService;
+//    }
     @GetMapping(value = "/login")
     public String login(){
         return "account/login";
@@ -32,10 +34,37 @@ public class AccountController {
         return "account/signup";
     }
 
-    @PostMapping(value = "/signup", produces="application/json; charset=utf-8")
+    // 이메일 인증
+    @GetMapping(value = "/email")
     @ResponseBody
-    public ResponseEntity<Object> save(@RequestBody(required = true) UserDto userDto){
-        // 회원가입을 시키기 위해서는 받은 정보를 저장해야 한다.
+    public String checkEmail(String email) {
+        System.out.println("받은 이메일 : " + email);
+
+        String data = emailAuthService.joinEmail(email);
+        return data;
+    }
+
+    // 회원가입
+    @PostMapping(value = "/signup")
+    @ResponseBody
+    public ResponseEntity<Object> save(@RequestBody(required = true) UserDto userDto) {
+
+//        // 회원가입을 시키기 위해서는 받은 정보를 저장해야 한다.
+//        // DB에 기본정보 insert
+//        EmailAuthService.signUp(userDto);
+//        //임의의 authKey 생성 & 이메일 발송
+//        String authKey = emailAuthService.sendAuthMail(userDto.getEmail());
+//        userDto.setAuthKey(authKey);
+//
+//        Map<String, String> map = new HashMap<String, String>();
+//        map.put("email", userDto.getEmail());
+//        map.put("authKey", userDto.getAuthKey());
+//        System.out.println("저장된 사용자 이메일"+map);
+//
+//        //DB에 authKey 업데이트
+//        EmailAuthService.updateAuthKey(map);
+//
+//        // 중복 확인 + 데이터 저장
         ResponseEntity<Object> data = accountService.signup(userDto);
         return data;
     }

--- a/src/main/java/daangnmarket/daangntoyproject/user/domain/EmailAuthMember.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/domain/EmailAuthMember.java
@@ -1,0 +1,33 @@
+package daangnmarket.daangntoyproject.user.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.persistence.*;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+
+@Entity
+@Getter
+@Table(name = "tb_email_auth_member")
+public class EmailAuthMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    private String email;
+    @Column(name = "auth_key")
+    private String authKey;
+    @Column(name = "auth_status")
+    private int authStatus;
+
+    public EmailAuthMember(){}
+
+    @Builder
+    public EmailAuthMember(String email, String authKey, int authStatus){
+        this.email = email;
+        this.authKey = authKey;
+        this.authStatus = authStatus;
+    }
+
+
+}

--- a/src/main/java/daangnmarket/daangntoyproject/user/model/KakaoUserDto.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/model/KakaoUserDto.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString(exclude = "KakaoUserDto")
+@ToString
 public class KakaoUserDto {
     private long id;
     private String email;

--- a/src/main/java/daangnmarket/daangntoyproject/user/model/UserDto.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/model/UserDto.java
@@ -15,9 +15,11 @@ public class UserDto {
     private String userId;
     private String userPassword;
     private String nickname;
-    private String email;
+    private String email;       // email 인증
     private String imgUrl;
     private boolean enabled;
+    private String authKey;     // email 인증
+    private int authStatus;     // email 인증
 
 
     public UserDto(String userId, String userPassword, String nickname

--- a/src/main/java/daangnmarket/daangntoyproject/user/repository/EmailAuthRepository.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/repository/EmailAuthRepository.java
@@ -1,0 +1,10 @@
+package daangnmarket.daangntoyproject.user.repository;
+
+import daangnmarket.daangntoyproject.user.domain.EmailAuthMember;
+import daangnmarket.daangntoyproject.user.model.UserDto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailAuthRepository extends JpaRepository<EmailAuthMember, Integer> {
+
+    UserDto findByEmail(String email);
+}

--- a/src/main/java/daangnmarket/daangntoyproject/user/service/AccountService.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/service/AccountService.java
@@ -61,7 +61,7 @@ public class AccountService {
         }
 
 //        // 로그인 처리
-        Authentication kakaoUsernamePassword = new UsernamePasswordAuthenticationToken(kakaoId, password);  // Collection<? extends GrantedAuthority> authorities 인수를 넣어줘야 인증이 완료 되는데, 안 넣어줘서 그런 듯
+        Authentication kakaoUsernamePassword = new UsernamePasswordAuthenticationToken(kakaoId, password);  // Collection<? extends GrantedAuthority> authorities 인수를 넣어줘야 인증이 완료 되는데, 안 넣어줘서 principal 사용 불가
         System.out.println("kakao 로그인 처리1 : "+kakaoUsernamePassword);
 //        Authentication authentication = authenticationManager.authenticate(kakaoUsernamePassword);
         SecurityContextHolder.getContext().setAuthentication(kakaoUsernamePassword);

--- a/src/main/java/daangnmarket/daangntoyproject/user/service/EmailAuthService.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/service/EmailAuthService.java
@@ -1,0 +1,90 @@
+package daangnmarket.daangntoyproject.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService implements EmailService{
+
+    @Autowired
+    private JavaMailSender mailSender;
+    private int authNumber;     // 난수 발생
+
+    public void makeRandomNumber() {
+        // 난수의 범위 111111 ~ 999999 (6자리 난수)
+        Random r = new Random();
+        int checkNum = r.nextInt(888888) + 111111;
+        System.out.println("인증번호 : " + checkNum);
+        authNumber = checkNum;
+    }
+
+
+    //이메일 보낼 양식!
+    public String joinEmail(String email) {
+        makeRandomNumber();
+        String setFrom = "qhtmf2059@gmail.com"; // email-config에 설정한 자신의 이메일 주소를 입력
+        String toMail = email;
+        String title = "회원 가입 인증 이메일 입니다."; // 이메일 제목
+        String content =
+                "당근마켓 클론코딩 홈페이지를 방문해주셔서 감사합니다." +    //html 형식으로 작성 !
+                        "<br><br>" +
+                        "인증 번호는 " + authNumber + "입니다." +
+                        "<br><br>" +
+                        "회원가입 페이지로 돌아가 회원가입을 마치시기 바랍니다.";   // 이메일 내용
+        System.out.println("메일 데이터 : " + title);
+        System.out.println("메일 데이터 : " + content);
+        System.out.println("메일 데이터 : " + setFrom);
+
+        mailSend(setFrom, toMail, title, content);
+
+        return Integer.toString(authNumber);
+    }
+
+    //이메일 전송 메소드
+    public void mailSend(String setFrom, String toMail, String title, String content)  {
+        System.out.println("mailSend 확인 완료");
+//        MimeMessage message = mailSender.createMimeMessage();
+//        MimeMessageHelper helper = null;
+//        try {
+//            helper = new MimeMessageHelper(message, true, "utf-8");
+//        } catch (MessagingException e) {
+//            throw new RuntimeException(e);
+//        }
+//        try {
+//            helper.setFrom(setFrom);
+//            helper.setTo(toMail);
+//            helper.setSubject(title);
+//            helper.setText(content, true);
+//            System.out.println("mailSend 메일 보내기 1초 전");
+//            mailSender.send(message);
+//        } catch (MessagingException e) {
+//            throw new RuntimeException(e);
+//        }
+
+        MimeMessage mailMessage = mailSender.createMimeMessage();
+        try {
+            mailMessage.addRecipients(MimeMessage.RecipientType.TO, toMail);
+            mailMessage.setSubject(title);
+            mailMessage.setFrom(setFrom);
+            mailMessage.setText(content, "utf-8", "html");
+            System.out.println("mailSend 메일 보내기 1초 전");
+            mailSender.send(mailMessage);
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String sendSimpleMessage(String to) throws Exception {
+        return null;
+    }
+}
+

--- a/src/main/java/daangnmarket/daangntoyproject/user/service/EmailService.java
+++ b/src/main/java/daangnmarket/daangntoyproject/user/service/EmailService.java
@@ -1,0 +1,5 @@
+package daangnmarket.daangntoyproject.user.service;
+
+public interface EmailService {
+    String sendSimpleMessage(String to)throws Exception;
+}

--- a/src/main/resources/email.properties
+++ b/src/main/resources/email.properties
@@ -1,0 +1,11 @@
+mail.smtp.auth=true
+mail.smtp.starttls.required=true
+mail.smtp.starttls.enable=true
+mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+mail.smtp.socketFactory.fallback=false
+mail.smtp.port=465
+mail.smtp.socketFactory.port=465
+
+# admin ?? ??
+AdminMail.id = qhtmf2059@gmail.com
+AdminMail.password = dtgxkcnfagiodoxu

--- a/src/main/resources/static/css/account/login.css
+++ b/src/main/resources/static/css/account/login.css
@@ -1,0 +1,49 @@
+html,
+body {
+    height: 100%;
+}
+
+body {
+    display: flex;
+    align-items: center;
+    padding-top: 40px;
+    padding-bottom: 40px;
+    background-color: #f5f5f5;
+}
+
+.form-signin {
+    width: 100%;
+    max-width: 330px;
+    padding: 15px;
+    margin: auto;
+}
+
+.form-signin .checkbox {
+    font-weight: 400;
+}
+
+.form-signin .form-floating:focus-within {
+    z-index: 2;
+}
+
+.form-signin input[type="email"] {
+    margin-bottom: -1px;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+.form-signin input[type="password"] {
+    margin-bottom: 10px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+}
+
+.ml-4{
+    margin-left: 74px;
+}
+
+.btn-outline-orange{
+    border-color: #d5760b;
+    color: #d5760b;
+}
+

--- a/src/main/resources/static/css/home/home.css
+++ b/src/main/resources/static/css/home/home.css
@@ -1,0 +1,15 @@
+.home-center-image1{
+    background-size: 804px 685px;
+    background-repeat: no-repeat;
+    width: 100%;
+    height: 700px;
+    background-color:#FBF7F2;
+}
+
+.home-center-image2{
+    background-size: 500px 555px;
+    background-repeat: no-repeat;
+    width: 100%;
+    height: 700px;
+    background-position: 70%;
+}

--- a/src/main/resources/static/js/account/account.js
+++ b/src/main/resources/static/js/account/account.js
@@ -1,0 +1,37 @@
+
+// 회원가입 -> 페이지 이동이 필요한 경우에는 ajax 사용 x....
+const userSignup = () => {
+
+    const resultModal = (data) => {
+        const resModal = new bootstrap.Modal(document.getElementById("resultModal"), {
+            keyboard: false
+        })
+        resModal.show()
+        modalClose()
+    }
+    const modalClose = () => {
+        $(".modalClose").click(function(){
+            location.href="/";
+        })
+    }
+
+    const userId = $("#userId")[0].value;
+    const nickname = $("#nickname")[0].value;
+    const email = $("#email")[0].value;
+    const userPassword = $("#userPassword")[0].value;
+    const userDto = {userId, nickname, email, userPassword};
+    console.log(userDto);
+
+    $.ajax ({
+        type: "POST",
+        url: "/account/signup",
+        data: JSON.stringify(userDto),
+        contentType:"application/json; charset=UTF-8",
+        success: function(data, message){
+            resultModal(data);
+        },
+        error: function () {
+            alert("정보를 제대로 입력해주세요.");
+        }
+    });
+}

--- a/src/main/resources/templates/account/login.html
+++ b/src/main/resources/templates/account/login.html
@@ -13,8 +13,12 @@
 </head>
 <body>
 
-    <form class="form-signin" th:action="@{/account/login}" method="post" style="margin-top: 30px;">
-        <a th:href="@{/}"><img class="mb-4 ml-4" src="https://dnvefa72aowie.cloudfront.net/karrot-cs/etc/202007/0cf1d10235c37b2635c02719125da37cc1bd632518198b1e1da7f5a364156540.png" alt="" width="150" height="60"></a>
+    <form class="form-signin" th:action="@{/account/login}" method="post" style="margin-top: 30px; max-width: 400px;">
+        <div class="mb-4 d-flex justify-content-center">
+            <a th:href="@{/}">
+                <img src="https://dnvefa72aowie.cloudfront.net/karrot-cs/etc/202007/0cf1d10235c37b2635c02719125da37cc1bd632518198b1e1da7f5a364156540.png" alt="" width="195" height="60">
+            </a>
+        </div>
         <!--경고창-->
         <div th:if="${param.error}" class="alert alert-danger" role="alert">
             Invalid username and password.

--- a/src/main/resources/templates/account/signup.html
+++ b/src/main/resources/templates/account/signup.html
@@ -11,8 +11,12 @@
 </head>
 <body>
 
-<form class="form-signin" style="margin-top: 30px;">
-  <a th:href="@{/}"><img class="mb-4 ml-4" src="https://dnvefa72aowie.cloudfront.net/karrot-cs/etc/202007/0cf1d10235c37b2635c02719125da37cc1bd632518198b1e1da7f5a364156540.png" alt="" width="130" height="60"></a>
+<form class="form-signin" style="margin-top: 30px; max-width: 400px;">
+  <div class="mb-4 d-flex justify-content-center">
+    <a th:href="@{/}">
+      <img src="https://dnvefa72aowie.cloudfront.net/karrot-cs/etc/202007/0cf1d10235c37b2635c02719125da37cc1bd632518198b1e1da7f5a364156540.png" alt="" width="195" height="60">
+    </a>
+  </div>
   <div th:replace="fragments/signup-modal :: resultModal('회원가입 성공', '당근마켓 회원가입에 성공하였습니다. 다시 로그인 해주세요.')"></div>
   <!--경고창-->
   <div th:if="${param.error}" class="alert alert-danger" role="alert">
@@ -27,6 +31,10 @@
     <input type="text" class="form-control" id="userId" name="userId" placeholder="userId">
     <label for="userId">아이디</label>
   </div>
+  <div class="form-floating">
+    <input type="password" class="form-control" id="userPassword" name="userPassword" placeholder="Password">
+    <label for="userPassword">패스워드</label>
+  </div>
   <div class="form-floating mb-1">
     <input type="text" class="form-control" id="nickname" name="nickname" placeholder="nickname">
     <label for="nickname">닉네임</label>
@@ -35,11 +43,14 @@
     <input type="text" class="form-control" id="email" name="email" placeholder="email">
     <label for="email">이메일</label>
   </div>
-  <div class="form-floating">
-    <input type="password" class="form-control" id="userPassword" name="userPassword" placeholder="Password">
-    <label for="userPassword">패스워드</label>
-    <p>영문자/숫자 8~20 사이로 입력해주세요.</p>
+  <div class="form-floating mb-1">
+    <button type="button" class="btn btn-outline-secondary" id="mail-check-btn">본인인증</button>
   </div>
+  <div class="form-floating mb-1">
+    <input type="text" class="form-control" id="email-auth" name="email-auth" placeholder="인증번호 6자리를 입력해주세요." disabled style="background-color: #b3b2b217">
+    <p id="mail-check-warn" class="mail-check-warn"></p>
+  </div>
+
   <button class="w-100 btn btn-lg btn-outline-orange" type="button" th:onclick="userSignup()">가입하기</button>
   <div class="d-flex justify-content-center" style="margin-top: 50px;">이미 회원가입을 했나요?</div>
 
@@ -54,8 +65,11 @@
 <!-- js -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
+<script src="https://code.jquery.com/jquery-3.5.0.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script th:src="@{/js/account/account.js}"></script>
+<script th:src="@{/js/account/mail.js}"></script>
+
 
 </body>
 </html>


### PR DESCRIPTION
> ⚙️구현 내용
- EmailConfig 파일과 email.properties 파일을 만들어서 이메일 인증을 위한 기본적인 설정을 하고, JavaMailSender의 bean을 생성해줬다.
- ajax를 통해서 비동기로 이메일 인증 번호를 전달하였다. 
- 서버에서는 random을 통해서 6자리 랜덤 숫자를 만들어내고, JavaMailSender객체를 통해서 이메일을 전달해줬다.

> 🖊️ 느낀 점 또는 부족한 부분
- 처음에는 EmailConfig에 bean을 생성해주지 않고 막무가내로 EmailAuthService에서 @Autowired를 사용하여 JavaMailSender를 자동 주입 하려고 했다. 하지만 @Autowired의 기본 개념을 생각해보면 당연히 @Bean 등록을 해줘야지만 자동주입이 가능한 것인데, 이번을 계기로 다시 한 번 자동 객체 주입(DI)에 대해 공부할 수 있었다.
- 또한 이번 계기로 build.gradle에서 라이브러리를 설치할 때 막무가내로 넣어버리면 충돌이 일어나 오류가 발생할 수 있다는 것을 알았다. ServiceConfigurationError로 인해 꽤 많은 시간을 허비했으면 이는 file - Invalidate Caches 를 통해서 해결할 수 있었다.

> 🔗이슈번호 : #7
>
