### PR TITLE
feature : 게시글 이미지 저장 및 게시글 수정 구현

### DIFF
--- a/src/main/java/daangnmarket/daangntoyproject/post/domain/Image.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/domain/Image.java
@@ -36,4 +36,5 @@ public class Image {
         this.imgName = imgName;
         this.imgUrl = imgUrl;
     }
+
 }

--- a/src/main/java/daangnmarket/daangntoyproject/post/domain/Post.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/domain/Post.java
@@ -1,20 +1,26 @@
 package daangnmarket.daangntoyproject.post.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import daangnmarket.daangntoyproject.post.model.PostSaveDto;
 import daangnmarket.daangntoyproject.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import javax.persistence.*;
 import java.sql.Date;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @Table(name="tb_post")
-public class Post {
+@DynamicInsert
+@DynamicUpdate
+public class Post { // dynamicInsert와 dynamicUpdate는 null인 값은 제외하고 추가해준다.
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
@@ -30,10 +36,10 @@ public class Post {
     private String postContent;
 
     @Column(name = "created_at")
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
     @Column(name = "updated_at")
-    private Date updatedAt;
+    private LocalDateTime updatedAt;
 
     private String status;  // O : 진행중 , R : 예약중, C : 거래완료
 
@@ -78,16 +84,18 @@ public class Post {
     public Post(){}
 
     @Builder
-    public Post(String postTitle, String postContent,
+    public Post(int PostId, String postTitle, String postContent,
                 int price, String proposalYn, int regionId, int categoryId, String userId,
-                LocalDate createdAt, Date updatedAt, String status, String deletedYn,
-                int viewCnt, int likeCnt)
-        {
+                LocalDateTime createdAt, LocalDateTime updatedAt, String status, String deletedYn,
+                int viewCnt, int likeCnt) {
+        if(postId != 0){
+            this.postId = postId;
+        }
         this.postTitle = postTitle;
         this.postContent = postContent;
         this.price = price;
         this.proposalYn = proposalYn;
-        this.createdAt = Date.valueOf(createdAt);
+        this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.status = status;
         this.deletedYn = deletedYn;
@@ -97,6 +105,15 @@ public class Post {
         this.setRegion(regionId);
         this.setCategory(categoryId);
 
+    }
+    public void update(PostSaveDto saveDto) {
+        this.postTitle = saveDto.getPostTitle();
+        this.postContent = saveDto.getPostContent();
+        this.price = Integer.parseInt(saveDto.getPrice().replaceAll(",", ""));
+        this.proposalYn = saveDto.getProposalYn();
+        this.updatedAt = LocalDateTime.now();
+        this.setRegion(saveDto.getRegionId());
+        this.setCategory(saveDto.getCategoryId());
     }
 
 }

--- a/src/main/java/daangnmarket/daangntoyproject/post/model/ImageDto.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/model/ImageDto.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
+
 @Getter
 @Setter
 @ToString
@@ -22,6 +24,13 @@ public class ImageDto {
                 .imgName(imgName)
                 .imgUrl(imgUrl)
                 .build();
+    }
+
+    public ImageDto(Image image){
+        this.imgId = image.getImgId();
+        this.imgUrl = image.getImgUrl();
+        this.imgName = image.getImgName();
+        this.postId = image.getPostId();
     }
 
 }

--- a/src/main/java/daangnmarket/daangntoyproject/post/model/PostDetailDto.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/model/PostDetailDto.java
@@ -13,6 +13,7 @@ import javax.persistence.Column;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.sql.Date;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -26,9 +27,9 @@ public class PostDetailDto {
 
     private String postContent;
 
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
-    private Date updatedAt;
+    private LocalDateTime updatedAt;
 
     private String status;  // O : 진행중 , R : 예약중, C : 거래완료
 

--- a/src/main/java/daangnmarket/daangntoyproject/post/model/PostSaveDto.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/model/PostSaveDto.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 
 import java.sql.Date;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Getter
@@ -21,9 +22,9 @@ public class PostSaveDto {
 
     private String postContent;
 
-    private Date createdAt;
+    private LocalDateTime createdAt;
 
-    private Date updatedAt;
+    private LocalDateTime updatedAt;
 
     private String status;  // O : 진행중 , R : 예약중, C : 거래완료
 
@@ -48,8 +49,7 @@ public class PostSaveDto {
                 .postContent(postContent)
                 .price(Integer.parseInt(price.replaceAll(",", "")))
                 .proposalYn(proposalYn)
-                .createdAt(LocalDate.now())
-                .updatedAt(updatedAt)
+                .createdAt(LocalDateTime.now())
                 .status("O")
                 .deletedYn("N")
                 .regionId(regionId)

--- a/src/main/java/daangnmarket/daangntoyproject/post/repository/ImageRepository.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/repository/ImageRepository.java
@@ -10,6 +10,5 @@ import java.util.List;
 public interface ImageRepository extends JpaRepository<Image, Integer> {
     @Query(value = "select img_id, post_id,img_name, img_url   from tb_image where post_id = :postId limit 1", nativeQuery = true)
     public Image findByPostIdResultOne(@Param(value = "postId") int postId);
-
     List<Image> findByPostId(int postId);
 }

--- a/src/main/java/daangnmarket/daangntoyproject/post/service/FileUtils.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/service/FileUtils.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 @Component
 public class FileUtils {
-    public static List<ImageDto> imageUpload(List<MultipartFile> images, int postId, HttpServletRequest request) throws IOException {
+    public static List<ImageDto> imageUpload(List<MultipartFile> images, int postId) throws IOException {
         List<ImageDto> imageDtos = new ArrayList<ImageDto>();
         ImageDto imageDto = null;
         String imgName = null;

--- a/src/main/java/daangnmarket/daangntoyproject/post/service/PostService.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/service/PostService.java
@@ -14,19 +14,14 @@ import daangnmarket.daangntoyproject.user.model.UserDto;
 import daangnmarket.daangntoyproject.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.swing.text.html.Option;
 import javax.transaction.Transactional;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Service
 public class PostService {
@@ -51,7 +46,7 @@ public class PostService {
         for(Post post:posts){
             Image topImage = imageRepository.findByPostIdResultOne(post.getPostId());
             postDtos.add(idx, new PostListDto(post));
-            postDtos.get(idx).setImgUrl(topImage.getImgUrl());    // 대표이미지 가져오기
+            postDtos.get(idx).setImgUrl(topImage.getImgUrl());
             idx++;
         }
         // 이미지 가져오기
@@ -60,7 +55,8 @@ public class PostService {
 
     @Transactional
     public PostDetailDto getPost(int pId, String userId) {
-        Optional<Post> postEntity = postRepository.findById(pId);
+        Post postEntity = postRepository.findById(pId).orElse(null);
+        System.out.println("postEntity 확인 = " + postEntity);
         PostDetailDto detailDto = new PostDetailDto(postEntity);    // userDto 저장 안되고 userId만 저장됨
         detailDto.setUserDto(new UserDto(userRepository.findById(detailDto.getUserId()))); // Post에는 userDto가 없기 때문에 따로 user 상세정보를 찾아서 넣어준다.
         detailDto.setImgUrl(imageRepository.findByPostId(pId));     // 이미지 저장
@@ -69,8 +65,8 @@ public class PostService {
         int visit = _check_visit(pId, userId);
         if(visit == 0){ // 방문 x
             detailDto.setViewCnt(detailDto.getViewCnt() + 1);
-            postEntity.get().setViewCnt(postEntity.get().getViewCnt() + 1);
-            postRepository.save(postEntity.get());
+            postEntity.setViewCnt(postEntity.getViewCnt() + 1);
+            postRepository.save(postEntity);
         }
         return detailDto;
     }
@@ -104,27 +100,70 @@ public class PostService {
     }
 
 
-    // 게시글 저장(추가 or 수정)
+    // 게시글 추가
     @Transactional
-    public ResponseEntity<Object> save(PostSaveDto saveDto, List<MultipartFile> images, HttpServletRequest request) throws IOException {
-        PostDetailDto postDetailDto = null;
-        if(saveDto.getPostId() == 0){   // 추가
-            postDetailDto = new PostDetailDto(postRepository.save(saveDto.toEntity()));
-        }else{                          // 수정
-//            saveDto.toEntity(postRepository.findById(saveDto.getPostId()));
-        }
+    public ResponseEntity<Object> save(PostSaveDto saveDto, List<MultipartFile> images) throws IOException {
+        PostDetailDto postDetailDto = new PostDetailDto(postRepository.save(saveDto.toEntity()));
 
         // 이미지 저장
-        if(!images.isEmpty()){          // images가 비어있지 않다면
-            List<ImageDto> imageDtos = FileUtils.imageUpload(images, postDetailDto.getPostId(), request);
+        saveImage(images, postDetailDto.getPostId());
+        ResponseEntity<Object> res = new ResponseEntity<>(postDetailDto, HttpStatus.OK);
+        return res;
+    }
+
+    public void saveImage(List<MultipartFile> images, int postId) throws IOException {
+        // 이미지 저장
+        if(images != null){
+            List<ImageDto> imageDtos = FileUtils.imageUpload(images, postId);
             for (ImageDto imageDto : imageDtos){
                 imageRepository.save(imageDto.toEntity());
             }
         }else{
-            ImageDto imageDto = FileUtils.defaultIamge(saveDto.getPostId());
+            ImageDto imageDto = FileUtils.defaultIamge(postId);
             imageRepository.save(imageDto.toEntity());
         }
+    }
+
+    @Transactional
+    public ResponseEntity<Object> modify(PostSaveDto saveDto, List<MultipartFile> images) throws IOException {
+        Post postEntity = postRepository.findById(saveDto.getPostId()).orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+        postEntity.update(saveDto);
+        PostDetailDto postDetailDto = new PostDetailDto();
+        postDetailDto.setPostId(saveDto.getPostId());
+
+        // 이미지 저장
+        saveImage(images, postDetailDto.getPostId());
         ResponseEntity<Object> res = new ResponseEntity<>(postDetailDto, HttpStatus.OK);
+
         return res;
+    }
+
+
+
+    // 이미지 가져오기
+    public List<ImageDto> getImages(int pId) {
+        List<Image> imageEntityList = imageRepository.findByPostId(pId);
+        List<ImageDto> imageDtos = new ArrayList<ImageDto>();
+        int idx = 0;
+        for (Image image : imageEntityList){
+            imageDtos.add(idx, new ImageDto(image));
+        }
+        System.out.println("이미지 리스트 가져오기 : "+ imageDtos);
+        return imageDtos;
+    }
+
+
+    // 이미지 삭제
+    public ResponseEntity<Object> deleteImage(int imgId) {
+        Image check = imageRepository.findById(imgId).orElse(null);
+        Map<String, String> message = new HashMap<String, String>();
+
+        if(check == null){
+            message.put("message", "error");
+        }else {
+            imageRepository.deleteById(imgId);
+            message.put("message", "success");
+        }
+        return new ResponseEntity<>(message, HttpStatus.OK);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,3 +10,7 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+## file size
+spring.servlet.multipart.maxFileSize=50MB
+spring.servlet.multipart.maxRequestSize=50MB

--- a/src/main/resources/static/js/post/post-form.js
+++ b/src/main/resources/static/js/post/post-form.js
@@ -5,6 +5,8 @@ const handleResize = () => {
 }
 
 const save = () =>{
+    const postId = $('#postId')[0].value;
+    console.log("save - postId 확인 = " + postId);
 
     const postTitle = $('#postTitle')[0].value;
     var price = $('#price')[0].value;
@@ -21,6 +23,7 @@ const save = () =>{
     }
 
     const data = {
+        "postId" : postId,
         "postTitle" : postTitle,
         "postContent" : postContent,
         "price" : price,
@@ -42,18 +45,34 @@ const save = () =>{
 
     // key 라는 이름으로 위에서 담은 data를 formData에 append한다.
     formData.append('saveDto', new Blob([JSON.stringify(data)], {type : "application/json"}));
+    if(postId == 0){
+        $.ajax({
+            url : '/post',
+            type : 'post',
+            data : formData,
+            contentType : false,                // 중요
+            processData : false,                // 중요
+            enctype : 'multipart/form-data',    // 중요
+            success : function (data) {
+                location.href="/post?pId=" + data.postId;
+            }
 
-    $.ajax({
-        url : '/post',
-        type : 'post',
-        data : formData,
-        contentType : false,                // 중요
-        processData : false,                // 중요
-        enctype : 'multipart/form-data',    // 중요
-        success : function (data) {
-            location.href="/post?pId=" + data.postId;
-        }
+        })
+    }else{
+        $.ajax({
+            url : '/post',
+            type : 'put',
+            data : formData,
+            contentType : false,                // 중요
+            processData : false,                // 중요
+            enctype : 'multipart/form-data',    // 중요
+            success : function (data) {
+                location.href="/post?pId=" + data.postId;
+            }
 
-    })
+        })
+
+    }
+
 }
 


### PR DESCRIPTION

> ⚙️구현 내용
- put method로 게시글을 수정하였다. 이때 게시글 이미지가 없이 저장을 한다면 default 이미지를 저장해주도록 하였다.
- ajax를 통해 x 버튼을 누르면 이미지가 삭제되도록 구현하였다.

> 🖊️ 느낀 점 또는 부족한 부분
- 게시글 추가 할 때 계속 nullPointException이 일어났다. 알고보니 비어 있는 객체에서 getPostId를 했기 때문에 발생한 문제였다. 이런 사소한 실수에 많은 시간을 뺏긴 것 같아서 시간이 너무 아까웠다.
- 이미지를 불러올 때 만약 이미지가 저장되어 있지 않다면 어떻게 해줘야 할까? 고민을 많이 했다. 나는 모든 게시글이 저장될 때 기본적으로 default 이미지가 저장되도록 설정해두었다. 하지만 이보다 더 좋은 방법이 있는지 고민해봐야겠다.
- 이미지를 비동기로 삭제할 때 onclick 이 안 먹혔는데, 이건 id명과 onclick 메소드명이 같을 때 반영이 되지 않는다는 것을 알았다. 웬만해서는 id명과 메소드명을 다르게 설정해야겠다.

> 🔗이슈번호 : #18 
>