### PR TITLE
feature : 게시글 작성시간 표기법 변경

### DIFF
--- a/src/main/java/daangnmarket/daangntoyproject/post/domain/Post.java
+++ b/src/main/java/daangnmarket/daangntoyproject/post/domain/Post.java
@@ -88,6 +88,7 @@ public class Post { // dynamicInsert와 dynamicUpdate는 null인 값은 제외�
                 int price, String proposalYn, int regionId, int categoryId, String userId,
                 LocalDateTime createdAt, LocalDateTime updatedAt, String status, String deletedYn,
                 int viewCnt, int likeCnt) {
+        // 구현하기
         if(postId != 0){
             this.postId = postId;
         }


### PR DESCRIPTION
- 기존에는 2022-12-10 12:13:10 이런 식으로 화면에 표기가 됐다면 몇 분 전, 몇 시간 전 이런 식으로 화면에 나오도록 구현하였다. 
- 처음에는 무조건 LocalDateTime의 format을 yyyy-MM-dd HH:mm:ss 이렇게 맞춰줘야 하는 줄 알고 생성자에서 format 맞춰 저장하느라 애먹었었다. 하지만 굳이 format을 맞춰주지 않아도 됐다. 
- PostSaveDto, PostDetailDto, Post(Entity) 모두 다 createAt, updateAt의 타입을 LocalDateTime으로 맞춰주고, format 맞춰줄 필요없이 그대로 프론트에 넘겨주면 된다. (format을 맞춰주려고 했던 이유가 javascript에서 date끼리 빼는 작업을 할 때 무조건  yyyy-MM-dd HH:mm:ss 이 형식이어야 하는 줄 알았기 때문이다.)
- js에서는 현재 시각과 createAt 시간을 뺀 다음에 milliSeconds를 초, 분, 시간 등으로 나누고, 그 값이 각각 60초, 60분, 24시간, .... 보다 작다면 '5분 전' (이건 예시) 이런 식으로 return 시켜준다.
 